### PR TITLE
Typo fix in mini-foss-universe.md

### DIFF
--- a/mini-foss-universe.md
+++ b/mini-foss-universe.md
@@ -10,7 +10,7 @@ Explore the open-source ecosystem around OpenAlgo — built for traders, by trad
 
 📦 **Historify** **(Full Stack Stock Market Data Management Platform)**\
 \
-[https://github.com/marketcalls/openalgo](https://github.com/marketcalls/historify)
+[https://github.com/marketcalls/historify](https://github.com/marketcalls/historify)
 
 🐍 **Python SDK Library**\
 \


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fixes the Historify GitHub link in mini-foss-universe.md to point to marketcalls/historify, ensuring readers land on the correct repository.

<!-- End of auto-generated description by cubic. -->

